### PR TITLE
Add a script to add frontmatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "hexo-renderer-stylus": "^0.3.1",
     "hexo-server": "^0.2.0",
     "js-yaml": "^3.8.3",
+    "klaw": "^1.3.1",
     "lodash": "^4.17.4",
-    "path": "^0.12.7"
+    "pify": "^2.3.0"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "^3.0.1"

--- a/source/index-pages/index.md
+++ b/source/index-pages/index.md
@@ -1,4 +1,5 @@
 category: default
+permalink: docs/index.html
 ---
 * [Developer Guide](developer-guide/collectors/how-to-develop-a-collector.html)
 * [User Guide](user-guide/rules/disallowed-headers.html)

--- a/themes/documentation/helper/index.js
+++ b/themes/documentation/helper/index.js
@@ -80,9 +80,17 @@ module.exports = function (hexo) {
             var result = (id === 'docs' || id === 'about');
             if (result) {
                 return options.fn(this);
-            } else {
-                return options.inverse(this);
             }
+            return options.inverse(this);
+        },
+        hasTocTitle: function (tocTitle, options) {
+            // Some files are placed directly under `developer-guide` or `user-guide`.
+            // These files don't contain `toc-title` entries in their front matter.
+            var result = (tocTitle !== 'undefined');
+            if (result) {
+                return options.fn(this);
+            }
+            return options.inverse(this);
         },
         getDocumentItems: function (navs) {
             // `navs` is the menu data saved in `menu.yml`.
@@ -94,7 +102,7 @@ module.exports = function (hexo) {
         },
         getSubPages: function (allPages, category) {
             return allPages.reduce(function (acc, page) {
-                 if(page.category === category) {
+                if (page.category === category) {
                     var tocTitle = page['toc-title'];
 
                     if (!acc[tocTitle]) {
@@ -102,9 +110,9 @@ module.exports = function (hexo) {
                     } else {
                         acc[tocTitle].push(page);
                     }
-                 }
+                }
 
-                 return acc;
+                return acc;
             }, {});
         }
     };

--- a/themes/documentation/layout/partials/sub-page.hbs
+++ b/themes/documentation/layout/partials/sub-page.hbs
@@ -27,7 +27,9 @@
                 </div>
                 <div class="module module--secondary table-of-contents" role="navigation">
                     {{#each pages}}
+                    {{#hasTocTitle @key}}
                     <p class="toc-section-title--active">{{@key}}</p>
+                    {{/hasTocTitle}}
                     <ul class="toc-subsection-title">
                         {{#each this}}
                         <li>

--- a/updater.js
+++ b/updater.js
@@ -1,0 +1,74 @@
+const klaw = require('klaw');
+const _ = require('lodash');
+const path = require('path');
+const pify = require('pify');
+
+const directory = path.resolve(process.argv[2]); // path to the folder that contains md files
+const filePaths = [];
+
+const fs = pify(require('fs'));
+
+console.log('Updater is initiated.');
+
+const generateFrontMatterInfo = (filePath, title) => {
+    const relativePath = path.relative(directory, filePath);
+    const baseName = path.basename(relativePath, '.md');
+
+    const [category, tocTitle] = path.dirname(relativePath).split(path.sep);
+    const permaLink = path.join('docs', path.dirname(relativePath), `${baseName}.html`);
+
+    const categoryFrontMatter = `category: ${category}`;
+    const titleFrontMatter = `title: ${title}`;
+    const permalinkFrontMatter = `permalink: ${permaLink}`;
+    const divider = '---';
+    const frontMatter = [categoryFrontMatter, titleFrontMatter, permalinkFrontMatter, divider];
+
+    if (tocTitle) {
+        const tocTitleFrontMatter = `toc-title: ${tocTitle}`;
+
+        frontMatter.unshift(tocTitleFrontMatter);
+    }
+
+    return frontMatter.join('\n');
+};
+
+const addFrontMatter = async (filePath) => {
+    let content;
+    const data = await fs.readFile(filePath, 'utf8');
+
+    if (data.includes('---')) {
+        // front matter already exists in this file, will update it
+        [, content] = data.split('---\n');
+    } else {
+        content = data;
+    }
+
+    const title = _.trim(content.match(/# (.*)\n\n/).pop().replace(/\(.*\)/, ''));
+
+    const frontMatter = generateFrontMatterInfo(filePath, title);
+
+    const newData = `${frontMatter}\n${content}`;
+
+    await fs.writeFile(filePath, newData);
+};
+
+
+
+// Iterate all the files in the dest folder and add frontmatter to each file
+klaw(directory)
+    .on('data', (item) => {
+        if (_.endsWith(item.path, '.md')) {
+            filePaths.push(item.path);
+        }
+    })
+    .on('error', (err, item) => {
+        console.log(err.message, item.path);
+    })
+    .on('end', async () => {
+        const promises = filePaths.map(addFrontMatter);
+
+        await Promise.all(promises);
+
+        console.log('Front Matter added to each file.')
+    });
+


### PR DESCRIPTION
* Given a path, extract the correct `category`, `title`, `toc-title` and `permalink` information from each file.
* Given a path, add front matter to each file.
* Move the docs index page to a separate folder so that it won't be replaced during the copying of files.
* Use regex to find `title` in each file to generate TOC.
* Use `path` module to process the the filePaths and generate front matter content.
* If the file already has front matter, update the existing front matter and avoid duplicity