### PR TITLE
Handle the difference in fragment identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "hexo-renderer-marked": "^0.3.0",
     "hexo-renderer-stylus": "^0.3.1",
     "hexo-server": "^0.2.0",
+    "hexo-util": "^0.6.0",
     "js-yaml": "^3.8.3",
     "klaw": "^1.3.1",
     "lodash": "^4.17.4",
@@ -29,6 +30,7 @@
   "scripts": {
     "build": "hexo generate",
     "hexo-server": "hexo server",
+    "hexo-clean": "hexo clean",
     "lint": "npm run lint-js && npm run lint-styles",
     "lint-browser": "eslint -c .eslintrc --env browser themes/documentation/source/**/*.js",
     "lint-js": "npm run lint-node && npm run lint-browser",

--- a/updater.js
+++ b/updater.js
@@ -2,6 +2,7 @@ const klaw = require('klaw');
 const _ = require('lodash');
 const path = require('path');
 const pify = require('pify');
+const util = require('hexo-util');
 
 const directory = path.resolve(process.argv[2]); // path to the folder that contains md files
 const filePaths = [];
@@ -32,23 +33,55 @@ const generateFrontMatterInfo = (filePath, title) => {
     return frontMatter.join('\n');
 };
 
+const escape = (html, encode) => {
+    return html
+        .replace(!encode ? /&(?!#?\w+;)/g : /&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+};
+
+// Update fragment identifiers to make links work in Hexo-generated pages
+const updateAnchors = (content) => {
+    // find all anchors containing links, example: '* [`scan::start`](#scanstart)\r\n'
+    const anchors = content.match(/\* \[`(.*)::(.*)`\]\(#(.*)\)(\n|\r\n)/g);
+
+    if (!anchors) {
+        return content;
+    }
+
+    // update anchor link format in markdown files
+    return _.reduce(anchors, (newContent, anchor) => { // example for an anchor: '* [`element::<element-type>`](#elementelement-type)'
+        const header = anchor.match(/\* \[`(.*)`\]/).pop(); // 'element::<element-type>'
+        const identifier = util.slugize(escape(header.trim())); // 'element-lt-element-type-gt'
+        const newAnchor = `* [\`${header}\`](#${identifier})\n`; // '* [`element::<element-type>`](#element-lt-element-type-gt)'
+
+        return newContent.replace(anchor, newAnchor);
+    }, content);
+};
+
 const addFrontMatter = async (filePath) => {
     let content;
     const data = await fs.readFile(filePath, 'utf8');
 
     if (data.includes('---')) {
         // front matter already exists in this file, will update it
-        [, content] = data.split('---\n');
+        [, content] = data.split('---');
     } else {
-        content = data;
+        content = `\n${data}`;
     }
 
-    const title = _.trim(content.match(/# (.*)\n\n/).pop()
-                         .replace(/\(.*\)/, ''));
+    // extract the first title in markdown file and remove the abbreviation in parenthesis
+    // example: '\r\n# Disallow certain HTTP headers (`disallow-headers`)\r\n\r\n' => 'Disallow certain HTTP headers'
+    const title = _.trim(content.match(/# (.*)(\n\n|\r\n\r\n)/)[1]
+        .replace(/\(.*\)/, ''));
 
     const frontMatter = generateFrontMatterInfo(filePath, title);
 
-    const newData = `${frontMatter}\n${content}`;
+    content = updateAnchors(content);
+
+    const newData = `${frontMatter}${content}`;
 
     await fs.writeFile(filePath, newData);
 };


### PR DESCRIPTION
The difference was due to the different ways that `::` is handled in the anchors: In Hexo, the `id` was generated by first `escape` and then `slugize` the anchor text. Although as @aarongustafson found, the anchored headings could be easily overriden by customizing the settings in `marked` (the markdown rendering module),  Hexo wrap it in another module called `hexo-renderer-marked` to make it compatible with Hexo, leaving limited access to enable this customization. So in this PR I propose a work-around using `updater.js` to update the markdown files in site:

- Anchor headings are located using regex
- Heading texts are escaped and then slugized to generate the hexo-style ids
- Replace the links in the markdown files