### PR TITLE
make footer responsive for demo + update mobile header

### DIFF
--- a/themes/documentation/layout/partials/header.hbs
+++ b/themes/documentation/layout/partials/header.hbs
@@ -3,7 +3,7 @@
         <nav class="nav">
             <a href="/" class="clear"><img src="{{url_for "images/sonar-logo.svg"}}" alt="sonar" class="header__logo navbar__navitem"></a>
             <input type="search" id="search-input" placeholder="Search..." class="hide">
-            <ul class="nav__navbar show">
+            <ul class="nav__navbar">
                 {{#each navs}}
                     <li class="navbar__navitem">
                         <a role="button" href="{{url_for link}}" id="{{id}}" aria-haspopup="true" aria-expanded="false" aria-controls="submenu-{{id}}" class="navitem__button">{{title}}</a>

--- a/themes/documentation/source/core/css/footer.css
+++ b/themes/documentation/source/core/css/footer.css
@@ -17,11 +17,22 @@ footer {
 .footer-nav {
     display: flex;
     align-items: flex-start;
+    flex-wrap: wrap;
+    flex-direction: column;
+    margin: 0 3rem;
+}
+
+@media (min-width: 32em) {
+
+    .footer-nav {
+        flex-direction: row;
+    }
+
 }
 
 .footer-nav__item {
     display: inline-block;
-    margin-right: 5rem;
+    margin: 0 5rem 5rem 0;
 }
 
 .footer-nav__item .category {


### PR DESCRIPTION
Made footer responsive. 

As a note about the header: @qzhou1607  I deleted the class "show" on the <ul> because it makes the mobile menu automatically visible. I believe this needs to be added to the <ul> via JS when the menu icon is clicked so it shows only when that icon is clicked. 