### PR TITLE
Add color syntax to code snippets

### DIFF
--- a/themes/documentation/layout/index.hbs
+++ b/themes/documentation/layout/index.hbs
@@ -17,6 +17,7 @@
         <link rel="stylesheet" href="{{url_for "core/css/navigation.css"}}">
         <link rel="stylesheet" href="{{url_for "core/css/structure.css"}}">
         <link rel="stylesheet" href="{{url_for "core/css/type.css"}}">
+        <link rel="stylesheet" href="{{url_for "core/css/highlight.css"}}">
         <link rel="stylesheet" href="{{url_for "components/breadcrumb/breadcrumb.css"}}">
         {{#if page.category}}
             <link rel="stylesheet" href="{{url_for "core/css/code.css"}}">

--- a/themes/documentation/source/core/css/code.css
+++ b/themes/documentation/source/core/css/code.css
@@ -18,7 +18,6 @@ pre,
 
 .highlight {
     border: 2px solid hsla(0, 0%, 0%, .03);
-    background: hsla(0, 0%, 0%, .03);
     margin-top: 2.4rem;
     margin-bottom: 2.4rem;
 }

--- a/themes/documentation/source/core/css/highlight.css
+++ b/themes/documentation/source/core/css/highlight.css
@@ -1,0 +1,75 @@
+.highlight {
+	background: #1d1f21;
+	padding: 10px 15px;
+	color: #c5c8c6;
+	overflow: auto;
+	margin: 0;
+}
+
+.highlight .line {
+	height: 22px;
+}
+
+pre .comment,
+pre .title {
+	color: #969896;
+}
+
+pre .variable,
+pre .attribute,
+pre .tag,
+pre .regexp,
+pre .ruby .constant,
+pre .xml .tag .title,
+pre .xml .pi,
+pre .xml .doctype,
+pre .html .doctype,
+pre .css .id,
+pre .css .class,
+pre .css .pseudo {
+	color: #c66;
+}
+
+pre .number,
+pre .preprocessor,
+pre .built_in,
+pre .literal,
+pre .params,
+pre .constant {
+	color: #de935f;
+}
+
+pre .class,
+pre .ruby .class .title,
+pre .css .rules .attribute {
+	color: #b5bd68;
+}
+
+pre .string,
+pre .value,
+pre .inheritance,
+pre .header,
+pre .ruby .symbol,
+pre .xml .cdata {
+	color: #b5bd68;
+}
+
+pre .css .hexcolor {
+	color: #8abeb7;
+}
+
+pre .function,
+pre .python .decorator,
+pre .python .title,
+pre .ruby .function .title,
+pre .ruby .title .keyword,
+pre .perl .sub,
+pre .javascript .title,
+pre .coffeescript .title {
+	color: #81a2be;
+}
+
+pre .keyword,
+pre .javascript .function {
+	color: #b294bb;
+}


### PR DESCRIPTION
@ststimac Here are some more options for the colors : [palettes](https://github.com/chriskempson/tomorrow-theme)