### PR TITLE
Add landing page in each section

### DIFF
--- a/source/_data/menu.yml
+++ b/source/_data/menu.yml
@@ -7,10 +7,10 @@
   link: /docs
   items:
   - id: developer-guide
-    link: docs/developer-guide/events/list-of-events.html
+    link: docs/developer-guide
     title: Developer Guide
   - id: user-guide
-    link: docs/user-guide/rules/disallowed-headers.html
+    link: docs/user-guide
     title: User Guide
 
 - title: About

--- a/source/docs/developer-guide/collectors/index.md
+++ b/source/docs/developer-guide/collectors/index.md
@@ -1,1 +1,7 @@
+---
+toc-title: collectors
+category: developer-guide
+title: Collectors
+permalink: docs/developer-guide/collectors/index.html
+---
 # Collectors

--- a/source/docs/developer-guide/events/index.md
+++ b/source/docs/developer-guide/events/index.md
@@ -1,1 +1,7 @@
+---
+toc-title: events
+category: developer-guide
+title: Events
+permalink: docs/developer-guide/events/index.html
+---
 # Events

--- a/source/docs/developer-guide/index.md
+++ b/source/docs/developer-guide/index.md
@@ -1,1 +1,6 @@
+---
+category: developer-guide
+title: Developer guide
+permalink: docs/developer-guide/index.html
+---
 # Developer guide

--- a/source/docs/developer-guide/rules/index.md
+++ b/source/docs/developer-guide/rules/index.md
@@ -1,1 +1,7 @@
+---
+toc-title: rules
+category: developer-guide
+title: Rules
+permalink: docs/developer-guide/rules/index.html
+---
 # Rules

--- a/source/docs/user-guide/index.md
+++ b/source/docs/user-guide/index.md
@@ -1,1 +1,6 @@
+---
+category: user-guide
+title: User guide
+permalink: docs/user-guide/index.html
+---
 # User guide

--- a/themes/documentation/helper/index.js
+++ b/themes/documentation/helper/index.js
@@ -1,4 +1,8 @@
 module.exports = function () {
+    const isIndexPage = (page, indexPageLevel) => {
+        return page.title.toLowerCase().replace(' ', '-') === page[indexPageLevel];
+    };
+
     return {
         /**
          * Handlebars Comparison Helpers
@@ -94,20 +98,8 @@ module.exports = function () {
             // `navs` is the menu data saved in `menu.yml`.
             return navs[1].items;
         },
-        getSubPages: function (allPages, category) { // eslint-disable-line object-shorthand
-            return allPages.reduce((acc, page) => {
-                if (page.category === category) {
-                    const tocTitle = page['toc-title'];
-
-                    if (!acc[tocTitle]) {
-                        acc[tocTitle] = [page];
-                    } else {
-                        acc[tocTitle].push(page);
-                    }
-                }
-
-                return acc;
-            }, {});
+        getToCIndexPageLink: (pages) => {
+            return pages.shift().permalink;
         },
         hasSubPage: function (id, options) { // eslint-disable-line object-shorthand
             const result = (id === 'docs' || id === 'about');
@@ -128,6 +120,28 @@ module.exports = function () {
             }
 
             return options.inverse(this);
+        },
+        // Sort out `Developer guide` or `User guide` pages
+        sortPagesByCategory: function (allPages, category) { // eslint-disable-line object-shorthand
+            return allPages.reduce((acc, page) => {
+                if (page.category === category) {
+                    const tocTitle = page['toc-title'];
+
+                    if (!acc[tocTitle]) {
+                        acc[tocTitle] = [];
+                    }
+
+                    if (isIndexPage(page, 'toc-title')) {
+                        acc[tocTitle].unshift(page); // always place index page as the first one
+                    }
+
+                    if (!isIndexPage(page, 'toc-title') && !isIndexPage(page, 'category')) { // non-index pages
+                        acc[tocTitle].push(page);
+                    }
+                }
+
+                return acc;
+            }, {});
         }
     };
 };

--- a/themes/documentation/layout/index.hbs
+++ b/themes/documentation/layout/index.hbs
@@ -40,11 +40,11 @@
             {{#if page.category}}
             <main class="container">
                 {{#compare page.category '===' 'developer-guide'}}
-                    {{>sub-page intro=site.data.developerGuide pages=(getSubPages site.pages.data 'developer-guide')}}
+                    {{>sub-page intro=site.data.developerGuide pages=(sortPagesByCategory site.pages.data 'developer-guide')}}
                 {{/compare}}
 
                 {{#compare page.category '===' 'user-guide'}}
-                    {{>sub-page intro=site.data.userGuide pages=(getSubPages site.pages.data 'user-guide')}}
+                    {{>sub-page intro=site.data.userGuide pages=(sortPagesByCategory site.pages.data 'user-guide')}}
                 {{/compare}}
 
                 {{#compare page.category '===' 'default'}}

--- a/themes/documentation/layout/partials/sub-page.hbs
+++ b/themes/documentation/layout/partials/sub-page.hbs
@@ -27,7 +27,11 @@
             <div class="module module--secondary table-of-contents" role="navigation">
                 {{#each pages}}
                     {{#hasTocTitle @key}}
-                        <p class="toc-section-title--active">{{@key}}</p>
+                        <p class="toc-section-title--active">
+                            <a href="{{getToCIndexPageLink ../this}}">
+                            {{@key}}
+                            </a>
+                        </p>
                     {{/hasTocTitle}}
                     <ul class="toc-subsection-title">
                         {{#each this}}

--- a/updater.js
+++ b/updater.js
@@ -4,6 +4,7 @@ const fs = pify(require('fs'));
 const klaw = require('klaw');
 const path = require('path');
 const util = require('hexo-util');
+const normalize = require('normalize-path');
 
 const directory = path.resolve(process.argv[2]); // path to the folder that contains md files
 const filePaths = [];
@@ -18,7 +19,7 @@ const generateFrontMatterInfo = (filePath, title) => {
     const baseName = path.basename(relativePath, '.md');
 
     const [category, tocTitle] = path.dirname(relativePath).split(path.sep);
-    const permaLink = path.join('docs', path.dirname(relativePath), `${baseName}.html`);
+    const permaLink = normalize(path.join('docs', path.dirname(relativePath), `${baseName}.html`));
 
     const categoryFrontMatter = `category: ${category}`;
     const titleFrontMatter = `title: ${title}`;
@@ -72,14 +73,14 @@ const addFrontMatter = async (filePath) => {
 
     if (data.includes(divider)) {
         // front matter already exists in this file, will update it
-        [, content] = data.split(divider);
+        [, , content] = data.split(divider); // ['', '<front matter>', '<Actual content in the markdown file>']
     } else {
         content = `\n${data}`;
     }
 
     // extract the first title in markdown file and remove the abbreviation in parenthesis
     // example: '\r\n# Disallow certain HTTP headers (`disallow-headers`)\r\n\r\n' => 'Disallow certain HTTP headers'
-    const title = _.trim(content.match(/# (.*)(\n\n|\r\n\r\n)/)[1]
+    const title = _.trim(content.match(/# (.*)(\n|\r\n)/)[1]
         .replace(/\(.*\)/, ''));
 
     const frontMatter = generateFrontMatterInfo(filePath, title);


### PR DESCRIPTION
Add landing page in each section

* Add landing page for `developer guide` and `user guide`.
* Add landing page for each section in ToC.
* Modify helper and template so that landing pages are not included as subpages in ToC.
* Make ToC title clickable and link them to landing pages.