### PR TITLE
Enable footer in all pages

### DIFF
--- a/hexo/themes/documentation/layout/index.hbs
+++ b/hexo/themes/documentation/layout/index.hbs
@@ -54,8 +54,8 @@
             </main>
             {{else}}
                 {{>home}}
-                {{>footer navs=site.data.menu}}
             {{/if}}
+            {{>footer navs=site.data.menu}}
         {{/if}}
         <script src="{{url_for "js/script.js"}}"></script>
         <script src="{{url_for "core/scripts/form-validation.js"}}"></script>


### PR DESCRIPTION
The footer in all the other pages (other than the home page) looks as below. @ststimac Would you please confirm that it looks right?
![footer](https://cloud.githubusercontent.com/assets/20218531/26326377/bcddbb92-3eef-11e7-8bff-d142690aa715.PNG)

