### PR TITLE
Config files for setting up the scraper

### DIFF
--- a/.travis/.env
+++ b/.travis/.env
@@ -1,0 +1,2 @@
+APPLICATION_ID=application_id
+API_KEY=api_key

--- a/.travis/config.json
+++ b/.travis/config.json
@@ -1,0 +1,19 @@
+{
+  "index_name": "sonarwhal",
+  "start_urls": [
+    "https://sonarwhal.com/docs/"
+  ],
+  "stop_urls": [
+    "https://sonarwhal.com/docs/index.html"
+  ],
+  "selectors": {
+    "lvl0": ".page-intro h1",
+    "lvl1": ".module h1",
+    "lvl2": ".module h2",
+    "lvl3": ".module h3",
+    "lvl4": ".module h4",
+    "text": ".module p"
+  },
+  "min_indexed_level": 1,
+  "nb_hits": 459
+}


### PR DESCRIPTION
These are the config files needed for fixing #76. @alrra  I've sent you the credentials needed.

Detailed steps in setting up the scraper:
- Install python & pip
- `git clone https://github.com/algolia/docsearch-scraper.git`
- `cd docsearch-scraper`
- Install dependencies: `pip install --user -r requirements.txt`
- Download [driver](https://github.com/mozilla/geckodriver/releases), rename it to `wires`, make it accessible in `$PATH`
- Copy `.env` and `config.json` to `docsearch-scraper`, fill in the credentials
- Start scraping: `python docsearch run config.json`
- Information about scraping each file will be logged
- Will be asked a question at the end: `Do you want to update the nb_hits in config.json ? [y/n]:`  
- If you login onto [Algolia](https://www.algolia.com/users/sign_in), you should be able to see the results in `sonarwhal` under the `indices` tab
