### PR TITLE
Fix changelog page and modify the updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ db.json
 dist/
 node_modules/
 src/hexo/source/changelog/
-src/hexo/source/docs/
+src/hexo/source/docs/developer-guide
+src/hexo/source/docs/user-guide
 Thumbs.db

--- a/helpers/update-content.js
+++ b/helpers/update-content.js
@@ -1,4 +1,4 @@
-/* global config cp exec mkdir rm */
+/* global config cp exec rm */
 
 const shell = require('shelljs/global'); // eslint-disable-line no-unused-vars
 
@@ -9,9 +9,10 @@ const TMP_DIR = require('./mktemp')();
 config.fatal = true;
 
 exec(`git clone ${CLONE_URL}  "${TMP_DIR}"`);
-rm('-rf', `${SOURCE_DIR}/docs`);
-cp('-R', `${TMP_DIR}/docs`, `${SOURCE_DIR}/docs`);
-mkdir('-p', `${SOURCE_DIR}/changelog`);
-cp(`${TMP_DIR}/CHANGELOG.md`, `${SOURCE_DIR}/changelog/index.md`);
+rm('-rf', `${SOURCE_DIR}/docs/developer-guide`);
+rm('-rf', `${SOURCE_DIR}/docs/user-guide`);
+cp('-R', `${TMP_DIR}/docs/developer-guide`, `${SOURCE_DIR}/docs/developer-guide`);
+cp('-R', `${TMP_DIR}/docs/user-guide`, `${SOURCE_DIR}/docs/user-guide`);
+cp(`${TMP_DIR}/CHANGELOG.md`, `${SOURCE_DIR}/about/changelog/index.md`);
 
 rm('-rf', TMP_DIR);

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "travis-docsearch-scraper": "node helpers/run-docsearch-scraper.js",
     "travis-update": "npm run travis-update-content && .travis/update.sh",
     "travis-update-content": ".travis/is-travis.sh && .travis/set-up-ssh.sh && npm run update-content && npm run build",
-    "update-content": "node helpers/update-content.js && node helpers/updater.js src/hexo/source/docs"
+    "update-content": "node helpers/update-content.js && node helpers/updater.js src/hexo/source"
   }
 }

--- a/src/hexo/source/_data/menu.yml
+++ b/src/hexo/source/_data/menu.yml
@@ -16,6 +16,9 @@
   - id: faq
     title: Faq
     link: /about/faq/
+  - id: changelog
+    title: changelog
+    link: /about/changelog/
   - id: governance
     title: Governance
     link: /about/governance/

--- a/src/hexo/source/about/changelog/index.md
+++ b/src/hexo/source/about/changelog/index.md
@@ -1,0 +1,7 @@
+---
+title: HEAD
+toc-title: changelog
+category: about
+permalink: about/changelog/index.html
+---
+# HEAD

--- a/src/hexo/source/about/code-of-conduct/index.md
+++ b/src/hexo/source/about/code-of-conduct/index.md
@@ -1,5 +1,8 @@
 ---
-category: default
+title: Contributor Covenant Code of Conduct
+toc-title: code-of-conduct
+category: about
+permalink: about/code-of-conduct/index.html
 ---
 # Contributor Covenant Code of Conduct
 

--- a/src/hexo/source/about/contributors/index.md
+++ b/src/hexo/source/about/contributors/index.md
@@ -1,4 +1,7 @@
 ---
-category: default
+title: You are in Section `Contributors`
+toc-title: contributors
+category: about
+permalink: about/contributors/index.html
 ---
 # You are in Section `Contributors`

--- a/src/hexo/source/about/faq/index.md
+++ b/src/hexo/source/about/faq/index.md
@@ -1,4 +1,7 @@
 ---
-category: default
+title: You are in Section `Faq`
+toc-title: faq
+category: about
+permalink: about/faq/index.html
 ---
 # You are in Section `Faq`

--- a/src/hexo/source/about/governance/index.md
+++ b/src/hexo/source/about/governance/index.md
@@ -1,4 +1,7 @@
 ---
-category: default
+title: You are in Section `Governance`
+toc-title: governance
+category: about
+permalink: about/governance/index.html
 ---
 # You are in Section `Governance`

--- a/src/hexo/source/docs/index.md
+++ b/src/hexo/source/docs/index.md
@@ -1,6 +1,2 @@
----
-category: default
-permalink: docs/
----
 * [Developer Guide](developer-guide/)
 * [User Guide](user-guide/)

--- a/src/hexo/themes/documentation/helper/index.js
+++ b/src/hexo/themes/documentation/helper/index.js
@@ -70,6 +70,9 @@ module.exports = function () {
                 '>=': (l, r) => {
                     return l >= r;
                 },
+                belongsTo: (l, r) => {
+                    return r.includes(l);
+                },
                 typeof: (l, r) => {
                     return typeof l === r;
                 },

--- a/src/hexo/themes/documentation/layout/index.hbs
+++ b/src/hexo/themes/documentation/layout/index.hbs
@@ -54,7 +54,7 @@
                     {{>sub-page intro=site.data.userGuide pages=(sortPagesByCategory site.pages.data 'user-guide')}}
                 {{/compare}}
 
-                {{#compare page.category '===' 'default'}}
+                {{#compare page.category 'belongsTo' 'about, doc-index'}}
                     {{>single-page}}
                 {{/compare}}
             </main>


### PR DESCRIPTION
Fix #107
* Add back `changelog`
* Move `docs` index page inside `docs` folder
* Modify `updater.js` to update md files in the `about` folder and also docs `index.md`
* Modify helper and handlebar template to correctly render page
* Modify `update-content.js` so that `docs index.md` doesn't get removed during updates
* Fix a bug: `updater.js` no longer throws an error when md file has not title