### PR TITLE
Fix multiple minor issues in the sonar website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -74,7 +74,7 @@ marked:
   breaks: false
   smartLists: true
   smartypants: true
-  modifyAnchors: ''
+  modifyAnchors: 1
   autolink: true
 
 # Deployment

--- a/helpers/updater.js
+++ b/helpers/updater.js
@@ -55,7 +55,7 @@ const generateFrontMatterInfo = (filePath, title) => {
 
     permaLinks.set(baseName, permaLink); // populate permaLinks
 
-    insertFrontMatterItemIfExist('toc-title', tocTitle, frontMatter);
+    insertFrontMatterItemIfExist('tocTitle', tocTitle, frontMatter);
     insertFrontMatterItemIfExist('title', title, frontMatter);
 
     if (index) {

--- a/src/hexo/source/_data/developerGuide.yml
+++ b/src/hexo/source/_data/developerGuide.yml
@@ -1,2 +1,0 @@
-title: Developer Guide
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum

--- a/src/hexo/source/_data/menu.yml
+++ b/src/hexo/source/_data/menu.yml
@@ -1,6 +1,6 @@
 - title: Documentation
   id: docs
-  link: /docs
+  link: #
   items:
   - id: developer-guide
     link: /docs/developer-guide/
@@ -11,7 +11,7 @@
 
 - title: About
   id: about
-  link: /about/
+  link: #
   items:
   - id: faq
     title: Faq

--- a/src/hexo/source/_data/userGuide.yml
+++ b/src/hexo/source/_data/userGuide.yml
@@ -1,2 +1,0 @@
-title: User Guide
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum

--- a/src/hexo/source/about/changelog/index.md
+++ b/src/hexo/source/about/changelog/index.md
@@ -1,6 +1,6 @@
 ---
 title: HEAD
-toc-title: changelog
+tocTitle: changelog
 category: about
 permalink: about/changelog/index.html
 ---

--- a/src/hexo/source/about/code-of-conduct/index.md
+++ b/src/hexo/source/about/code-of-conduct/index.md
@@ -1,6 +1,6 @@
 ---
 title: Contributor Covenant Code of Conduct
-toc-title: code-of-conduct
+tocTitle: code-of-conduct
 category: about
 permalink: about/code-of-conduct/index.html
 ---

--- a/src/hexo/source/about/contributors/index.md
+++ b/src/hexo/source/about/contributors/index.md
@@ -1,6 +1,6 @@
 ---
 title: You are in Section `Contributors`
-toc-title: contributors
+tocTitle: contributors
 category: about
 permalink: about/contributors/index.html
 ---

--- a/src/hexo/source/about/faq/index.md
+++ b/src/hexo/source/about/faq/index.md
@@ -1,6 +1,6 @@
 ---
 title: You are in Section `Faq`
-toc-title: faq
+tocTitle: faq
 category: about
 permalink: about/faq/index.html
 ---

--- a/src/hexo/source/about/governance/index.md
+++ b/src/hexo/source/about/governance/index.md
@@ -1,6 +1,6 @@
 ---
 title: You are in Section `Governance`
-toc-title: governance
+tocTitle: governance
 category: about
 permalink: about/governance/index.html
 ---

--- a/src/hexo/themes/documentation/layout/index.hbs
+++ b/src/hexo/themes/documentation/layout/index.hbs
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>{{page.title}}</title>
+        <title>{{#compare page.category '||' isSection}}{{page.title}}{{else}}sonar, the linting tool for the web{{/compare}}</title>
         <meta name="description" content="sonar website">
         <meta name="viewport" content="width=device-width">
 

--- a/src/hexo/themes/documentation/layout/partials/sub-page.hbs
+++ b/src/hexo/themes/documentation/layout/partials/sub-page.hbs
@@ -3,9 +3,9 @@
         <ul>
             <li><a href="/">Home</a></li>
             <li>
-                <a {{#if (isSubPage page)}} href="../../"{{else}}href="../"{{/if}}>Documentation</a>
+                <a {{#if (isNotGuideIndexPage page)}} href="../../"{{else}}href="../"{{/if}}>Documentation</a>
             </li>
-            {{#if (isSubPage page)}}
+            {{#if (isNotGuideIndexPage page)}}
             <li>
                 <a href="../">
                     {{#compare page.category '===' 'user-guide'}}
@@ -29,46 +29,45 @@
             </div>
             <div class="module module--secondary table-of-contents treeview" role="navigation">
                 <ul role="tree" aria-labelledby="page-heading" tabindex="0">
-                {{#each pages}}
-                    {{#if this}}
-                        <li role="treeitem" aria-label="subsection" tabindex="0"
-                        {{#if (expandToC ../page this)}}
-                            aria-expanded = "true"
-                        {{else}}
-                            aria-expanded="false"
-                        {{/if}}>
-                            {{#hasTocTitle @key}}
-                            <div {{#if (expandToC ../../page ../this)}}
-                                         class="toc-section-title--active"
-                                    {{else}}
-                                         class="toc-section-title"
-                                    {{/if}}>
-                                <span class="text">{{@key}}</span>
-                                <span class="icon"></span>
-                            </div>
-                            {{/hasTocTitle}}
+                {{#each (getSortedToCTitles pages)}}
+                    <li role="treeitem" aria-label="subsection" tabindex="0"
+                    {{#compare ../page.tocTitle '===' this}}
+                        aria-expanded = "true"
+                    {{else}}
+                        aria-expanded="false"
+                    {{/compare}}>
+                        <div  {{#compare ../../page.tocTitle '===' this}}
+                                        class="toc-section-title--active"
+                                {{else}}
+                                        class="toc-section-title"
+                                {{/compare}}>
+                            <span class="text">{{this}}</span>
+                            <span class="icon"></span>
+                        </div>
 
-                                <ul class="toc-subsection-title" role="group">
-                                    {{#each this}}
-                                        <li role="treeitem"
-                                        {{#if (isSelected ../../page permalink)}}
-                                            aria-selected="true"
-                                        {{/if}}>
-                                            <div {{#compare ../../page.title '===' title}}
-                                                        class="toc-subsection-title--active"
-                                                        aria-current="location"
-                                                    {{else}}
-                                                        class="toc-subsection-title"
-                                                    {{/compare}}>
-                                                    <a class="text" href="{{permalink}}" {{#unless (expandToC ../../page ../this)}}tabindex="-1"{{/unless}}>
-                                                        {{title}}
-                                                    </a>
-                                            </div>
-                                        </li>
-                                    {{/each}}
-                                </ul>
-                            </li>
-                        {{/if}}
+                        <ul class="toc-subsection-title" role="group">
+                            {{#each (getPagesByToCTitle this ../pages)}}
+                                <li role="treeitem"
+                                {{#compare ../../page.title '===' title}}
+                                    aria-selected="true"
+                                {{/compare}}>
+                                    <div {{#compare ../../page.title '===' title}}
+                                                class="toc-subsection-title--active"
+                                                aria-current="location"
+                                            {{else}}
+                                                class="toc-subsection-title"
+                                            {{/compare}}>
+                                        <a class="text" href="{{permalink}}"
+                                            {{#compare ../../page.tocTitle '!==' ../this}}
+                                                tabindex="-1"
+                                            {{/compare}}>
+                                            {{title}}
+                                        </a>
+                                    </div>
+                                </li>
+                            {{/each}}
+                        </ul>
+                    </li>
                 {{/each}}
                 </ul>
             </div>


### PR DESCRIPTION
* Fix title in home page, Fix #125
* Modify Sort page helper function
* Use lowercase anchorId so that same-pagelinks should work, Fix #124
* Remove unnecessary helpers
* Add sort function to guarantee that `user guide` and `developer guide` have the same order of ToC titles, Fix #118
* Clean up `subpage.hb`