### PR TITLE
Fix links to `.md` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "handlebars": "^4.0.6",
     "hexo": "^3.3.7",
     "hexo-cli": "^1.0.2",
-    "hexo-generator-index": "^0.2.0",
+    "hexo-generator-index": "^0.2.1",
     "hexo-generator-tag": "^0.2.0",
     "hexo-hrefmd": "^1.0.1",
     "hexo-renderer-handlebars": "^2.0.2",
@@ -35,7 +35,7 @@
   },
   "private": true,
   "scripts": {
-    "build": "node helpers/updater.js src/hexo/source && hexo generate",
+    "build": "npm run hexo:clean && node helpers/updater.js src/hexo/source && hexo generate",
     "hexo:clean": "hexo clean",
     "hexo:server": "hexo server",
     "lint": "npm-run-all lint:*",


### PR DESCRIPTION
Fix #48 

It seems that if the current pages in `dist` don't get cleaned up before running `build`, the links are not updated. So I added `npm run hexo:clean` in `build`. What `hexo clean` does include:
- Delete `db.json`.
- Delete `dist`. 

I don't think anything needs to be changed in the travis script, my understanding is that travis just takes whatever generated in `dist` and copy it to the branch, it happens after `hexo generate` so it should not affect the rendering process. @alrra Am I right?