### PR TITLE
Fix broken github link

### DIFF
--- a/src/webhint-theme/layout/partials/home.hbs
+++ b/src/webhint-theme/layout/partials/home.hbs
@@ -54,7 +54,7 @@
                             <a href="/docs/contributor-guide/getting-started/pull-requests/">contributing code</a>, and improving the documentation
                             are just the start!
                         </p>
-                        <a class="feature__cta" href="https://github.com/webhint">webhint GitHub</a>
+                        <a class="feature__cta" href="https://github.com/webhintio">webhint GitHub</a>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

Fixed a github link pointing to https://github.com/webhint instead of https://github.com/webhintio.
