### PR TITLE
Fix: Sort category documents alphabetically with `summary.md` at the top

### DIFF
--- a/src/webhint-theme/helper/utils.js
+++ b/src/webhint-theme/helper/utils.js
@@ -77,9 +77,29 @@ module.exports = {
             return !hint.isSummary;
         }).length;
     },
+    /**
+     * Returns all the pages under a given `title` sorted alphabetically
+     * unless the file is `summary.md` in which case it will be the first
+     * one.
+     * E.g.:
+     * Server configurations:
+     *  - Examples of server configurations (`summary.md`)
+     *  - Basic server configuration for Apache (`apache.md`)
+     *  - Basic `web.config` for IIS (`iis.md`)
+     */
     getPagesByToCTitle: (title, pages) => {
         return pages[title].filter((page) => {
             return page.contentType === 'details';
+        }).sort((a, b) => {
+            if (a.originalFile.endsWith('summary.md')) {
+                return -1;
+            }
+
+            if (b.originalFile.endsWith(`summary.md`)) {
+                return 1;
+            }
+
+            return a.title > b.title;
         });
     },
     getSignalIssueQuery: (root, title, directory) => {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

Partially solves #520 by making sure that the content of `summary.md` in
any subsection is always the first one in the table of content.

To fully fix #520 we need to update the docs in webhintio/hint but this can be merged without waiting on that.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #520

<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
