### PR TITLE
Fix: Verification with Bing and Google and update sitemap on push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ script:
              travis_wait 30 npm run travis-update \
               && npm run test-staging \
               && npm run swap
+              # Tell Google to update the sitemap (https://support.google.com/webmasters/answer/183668?hl=en#addsitemap)
+              && curl https://www.google.com/ping?sitemap=https://webhint.io/sitemap.xml
+              # Tell Bing to update the sitemap (https://www.bing.com/webmaster/help/how-to-submit-sitemaps-82a15bd4)
+              && curl https://www.bing.com/ping?sitemap=https://webhint.io/sitemap.xml
         fi
 
 language: node_js

--- a/src/webhint-theme/source/BingSiteAuth.xml
+++ b/src/webhint-theme/source/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>90B809F445576BFF4CBA49B063DF7C42</user>
+</users>

--- a/src/webhint-theme/source/googlec79886d7cae0f795.html
+++ b/src/webhint-theme/source/googlec79886d7cae0f795.html
@@ -1,0 +1,1 @@
+google-site-verification: googlec79886d7cae0f795.html


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

After the migration from sonarwhal.com to webhint.io Google dropped
the verification. This adds the required files to make sure we are
verified in both search engines and adds an extra step in the build
process to tell them to fetch the sitemap so links in their cache
are updated faster.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #551

<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
