### PR TITLE
Add github link to menu

### DIFF
--- a/src/content/_data/menu.yml
+++ b/src/content/_data/menu.yml
@@ -32,3 +32,7 @@
   - id: code-of-conduct
     title: Code of Conduct
     link: https://js.foundation/community/code-of-conduct
+
+- title: GitHub
+  id: github
+  link: https://github.com/webhintio


### PR DESCRIPTION
Please review, never worked with yaml. If I haven't missed anything, this PR should add a webhint.io github repo link to the menu as suggested in https://github.com/webhintio/webhint.io/issues/491.

<hr>

As this is my first PR:
- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)