### PR TITLE
Don't display the GitHub link on larger viewports

### DIFF
--- a/src/webhint-theme/source/core/css/navigation.css
+++ b/src/webhint-theme/source/core/css/navigation.css
@@ -75,7 +75,8 @@
 
 @media (min-width: 48em) {
 
-    .nav-bar--mobile-buttons {
+    .nav-bar--mobile-buttons,
+    .navbar__navitem #github {
         display: none;
     }
 


### PR DESCRIPTION
At the current break-points, the menu breaks if the link is displayed when the menu is not collapsed. So better hide it at larger viewports for now. Forgot to do this in https://github.com/webhintio/webhint.io/pull/557