### PR TITLE
Fix: Enable `Clear-Site-Data` for sonarwhal.com

### DIFF
--- a/web.config
+++ b/web.config
@@ -90,7 +90,16 @@
                 </rewriteMap>
             </rewriteMaps>
             <outboundRules>
-                <!-- Restore the mime type for compressed assets. See below for more explanation -->
+                <!-- Clean service worker from old site -->
+                <rule name="sonarwhal" enabled="true">
+                    <match serverVariable="RESPONSE_Clear_Site_Data" pattern=".*" />
+                    <conditions>
+                            <add input="{HTTP_HOST}" pattern="^sonarwhal.com" />
+                    </conditions>
+                    <action type="Rewrite" value="storage" />
+                </rule>
+
+               <!-- Restore the mime type for compressed assets. See below for more explanation -->
                 <rule name="RestoreMime" enabled="true">
                     <match serverVariable="RESPONSE_Content_Type" pattern=".*" />
                     <conditions>


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

The old website had a service worker that it is still causing people to
see the old content instead of the new. One of the strategies to fix
this is to use the new `Clear-Site-Data` header supported by Chrome and
Firefox. This PR add this header header only for requests comming to
sonarwhal.com while leaving the rest untouched.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix: #544


This `web.config` is already in production and this is the network trace:

![image](https://user-images.githubusercontent.com/606594/47938955-e0a86280-dea2-11e8-9150-db433e30b2c5.png)

I don't know how to verify this is actually working as I don't have the old service worker installed 


<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
