### PR TITLE
Update coloring of TOC indicator

### DIFF
--- a/src/webhint-theme/source/images/toc-current-section.svg
+++ b/src/webhint-theme/source/images/toc-current-section.svg
@@ -1,10 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 15.4 12.4" style="enable-background:new 0 0 15.4 12.4;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#4700A3;}
-</style>
-<path class="st0" d="M12,0.2c-2.1,0-3.9,1.4-4.3,3.3C7.3,1.7,5.5,0.2,3.4,0.2H0.2v1.5c0,3.1,2.7,5.6,6,5.6h0.3l-1.7,4.9h5.9L8.9,7.4
-	h0.3c3.3,0,6-2.5,6-5.6V0.2H12z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15.4 12.4">
+  <path d="M12 .2C9.9.2 8.1 1.6 7.7 3.5 7.3 1.7 5.5.2 3.4.2H.2v1.5c0 3.1 2.7 5.6 6 5.6h.3l-1.7 4.9h5.9L8.9 7.4h.3c3.3 0 6-2.5 6-5.6V.2H12z" fill="#4700a3"/>
 </svg>

--- a/src/webhint-theme/source/images/toc-current-section.svg
+++ b/src/webhint-theme/source/images/toc-current-section.svg
@@ -1,1 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15.4 12.4"><path fill="#4046dd" d="M12 .2C9.9.2 8.1 1.6 7.7 3.5 7.3 1.7 5.5.2 3.4.2H.2v1.5c0 3.1 2.7 5.6 6 5.6h.3l-1.7 4.9h5.9L8.9 7.4h.3c3.3 0 6-2.5 6-5.6V.2H12z"/></svg>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 15.4 12.4" style="enable-background:new 0 0 15.4 12.4;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#4700A3;}
+</style>
+<path class="st0" d="M12,0.2c-2.1,0-3.9,1.4-4.3,3.3C7.3,1.7,5.5,0.2,3.4,0.2H0.2v1.5c0,3.1,2.7,5.6,6,5.6h0.3l-1.7,4.9h5.9L8.9,7.4
+	h0.3c3.3,0,6-2.5,6-5.6V0.2H12z"/>
+</svg>


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

Currently the table of contents current section indicator is the old purple color:

![color-update](https://user-images.githubusercontent.com/18073131/48437611-a8bcdd00-e736-11e8-9c93-dac195d597aa.PNG)

Updating to match the darker purple.


