### PR TITLE
Fix: Hints within a multi-hint should not appear in the ToC

### DIFF
--- a/helpers/updater.js
+++ b/helpers/updater.js
@@ -121,7 +121,20 @@ const generateFrontMatterInfo = (filePath, title, description, currentFrontMatte
     baseName = path.basename(relativePath, '.md');
     baseName = baseName !== 'index' ? baseName : '';
 
-    const [category, tocTitle] = path.dirname(relativePath).split(path.sep);
+    const splittedPath = path.dirname(relativePath).split(path.sep);
+    let category = splittedPath[0];
+    const tocTitle = splittedPath[1];
+
+    /**
+     * Hints documentation in a multi-hints shouldn't be indexed
+     * in the ToC, just the index.
+     * In these cases, splittedPath will have this shape:
+     *      ['user-guide', 'hints', 'hint-xxxxxx']
+     */
+    if (splittedPath.length > 2 && splittedPath[2].startsWith('hint-')) {
+        category = 'multi-hint';
+    }
+
     const originalFile = normalize(path.join(root, relativePath)).toLowerCase();
     const permalink = normalize(path.join(root, path.dirname(relativePath), baseName, 'index.html')).toLowerCase();
     const layout = getLayout(filePath);


### PR DESCRIPTION
Fix #583

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
