### PR TITLE
Re-center text on homepage

### DIFF
--- a/src/webhint-theme/source/core/css/home.css
+++ b/src/webhint-theme/source/core/css/home.css
@@ -73,7 +73,7 @@ a.home--hero__images-wrap:focus {
     text-overflow: ellipsis;
 }
 
-.module .feature {
+.module.feature {
     display: flex;
     align-items: center;
     flex-direction: column;


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

Staging site showing this section became uncentered: 

![uncentered](https://user-images.githubusercontent.com/18073131/54772570-da522300-4bc4-11e9-9430-54e1dc823f2d.JPG)

This PR fixes that.

