### PR TITLE
Fix: Add `title` to html links, only if it is present in docs

### DIFF
--- a/src/webhint-theme/scripts/custom-renderer.js
+++ b/src/webhint-theme/scripts/custom-renderer.js
@@ -48,7 +48,7 @@ renderer.code = (code, lang) => {
 };
 
 renderer.link = (href, title, text) => {
-    return `<a${isExternalLink(href) ? ' target="_blank"' : ''} href="${href}" title="${title}">${text}</a>`;
+    return `<a${isExternalLink(href) ? ' target="_blank"' : ''} href="${href}" ${title ? ` title="${title}"` : ''}>${text}</a>`;
 };
 
 renderer.heading = (text, level) => {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

Fixes bug in hexo link renderer.
Before this commit, `title` was being added to each link as `null`.

## Details

Most links in webhint docs do not have title.
When these markdown docs are getting converted to html by `hexo`, `title="null"` is getting embedded in all links. And on hover, null is shown as tooltip. This doesn't look good. See below:

![title-as-null](https://user-images.githubusercontent.com/10244949/62002028-f5581500-b119-11e9-8853-91e0f412e0a6.gif)

After fix:

![title-fixed](https://user-images.githubusercontent.com/10244949/62002202-dc049800-b11c-11e9-9e25-afa03992ac21.gif)
