### PR TITLE
Fix: OpenJSF header text color

### DIFF
--- a/src/webhint-theme/source/core/css/navigation.css
+++ b/src/webhint-theme/source/core/css/navigation.css
@@ -115,6 +115,10 @@
     color: #fff;
 }
 
+.openjsf-header {
+    color: #fff;
+}
+
 .openjsf-header a, .openjsf-header a:visited {
     color: #fff;
     text-decoration: underline;


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

Non-link text in the OpenJSF header outside of the home page need to be explicitly set to white
