### PR TITLE
Add support to accept scan url in query

### DIFF
--- a/src/server/routes/scanner.js
+++ b/src/server/routes/scanner.js
@@ -264,7 +264,8 @@ const configure = (app, appInsightsClient) => {
                     description: `Analyze any public website using webhint's online tool`,
                     title: `webhint's online scanner`
                 },
-                result: null
+                result: null,
+                scanUrl: req.query.url
             });
         };
     }

--- a/src/webhint-theme/layout/partials/scan-form.ejs
+++ b/src/webhint-theme/layout/partials/scan-form.ejs
@@ -148,7 +148,7 @@
                 <form action="/scanner/" method="POST">
                     <label for="scanner-page-scan">Enter your URL here</label>
                     <div class="input-fix">
-                        <input id="scanner-page-scan" type="url" name="url" placeholder="Type your URL here">
+                        <input id="scanner-page-scan" type="url" name="url" value="<%= scanUrl || '' %>" placeholder="Type your URL here">
                         <button class="button--red" type="submit" data-ga-category="scanner" data-ga-action="start" data-ga-label="scanner">Run Scan</button>
                     </div>
                 </form>

--- a/src/webhint-theme/layout/scan.ejs
+++ b/src/webhint-theme/layout/scan.ejs
@@ -26,7 +26,7 @@
     <% if (result) { %>
         <%- include('partials/scan-result-container', { result, utils, showQueue, getMessage }); %>
     <% } else { %>
-        <%- include('partials/scan-form'); %>
+        <%- include('partials/scan-form', { scanUrl }); %>
     <% } %>
 
     <%- include('partials/footer', { navs: site.data.menu }); %>


### PR DESCRIPTION

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)
As per feature request, we can allow the URL in query to be auto populated in input field.

Could we make it more helpful for user? Any thoughts please.

What about start the scanning process if there is a valid URL in query?

Fix: #654

<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
