### PR TITLE
Docs: Fix category used for VS Code extension

### DIFF
--- a/helpers/update-site/documentation.js
+++ b/helpers/update-site/documentation.js
@@ -234,7 +234,7 @@ const getResourcesFiles = async () => {
             name = nameSplitted[nameSplitted.length - 1];
         }
 
-        const resourceType = nameSplitted[0].split('-')[0];
+        const resourceType = name === 'vscode-webhint' ? 'extension' : nameSplitted[0].split('-')[0];
         const dir = path.join(process.cwd(), constants.dirs.USER_GUIDE, `${resourceType}s`, nameSplitted.slice(0, nameSplitted.length - 1).join('/'));
         const dest = `${dir}/${name}.md`;
 


### PR DESCRIPTION
Now appears under "Extensions" instead of "Vscodes".

- - - - - - - - - -

Fix webhintio/hint#2929

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
