### PR TITLE
Webfont improvements

### DIFF
--- a/src/webhint-theme/layout/partials/styles.ejs
+++ b/src/webhint-theme/layout/partials/styles.ejs
@@ -1,3 +1,7 @@
+<link rel="preload" href="/static/fonts/montserrat-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="/static/fonts/montserrat-300.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="/static/fonts/source-sans-pro.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="/static/fonts/montserrat-500.woff2" as="font" type="font/woff2" crossorigin>
 <!-- build:css /static/styles/common.css -->
 <link rel="stylesheet" href="/core/css/fonts.css">
 <link rel="stylesheet" href="/core/css/about.css">

--- a/src/webhint-theme/source/core/css/fonts.css
+++ b/src/webhint-theme/source/core/css/fonts.css
@@ -2,6 +2,7 @@
     font-family: "Montserrat";
     font-style: normal;
     font-weight: 300;
+    font-display: swap;
     src: local("Montserrat Light"), local("Montserrat-Light"), url("/static/fonts/montserrat-300.woff2") format("woff2"), url("/static/fonts/montserrat-300.woff") format("woff");
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -10,6 +11,7 @@
     font-family: "Montserrat";
     font-style: normal;
     font-weight: 400;
+    font-display: swap;
     src: local("Montserrat Regular"), local("Montserrat-Regular"), url("/static/fonts/montserrat-400.woff2") format("woff2"), url("/static/fonts/montserrat-400.woff") format("woff");
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -18,6 +20,7 @@
     font-family: "Montserrat";
     font-style: normal;
     font-weight: 500;
+    font-display: swap;
     src: local("Montserrat Medium"), local("Montserrat-Medium"), url("/static/fonts/montserrat-500.woff2") format("woff2"), url("/static/fonts/montserrat-500.woff") format("woff");
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -26,6 +29,7 @@
     font-family: "Source Sans Pro";
     font-style: normal;
     font-weight: 400;
+    font-display: swap;
     src: local("Source Sans Pro Regular"), local("SourceSansPro-Regular"), url("/static/fonts/source-sans-pro.woff2") format("woff2"), url("/static/fonts/source-sans-pro.woff") format("woff");
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [ ] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

- Preload to make fonts fetch and render faster
- Uses `font-display: swap` to get rid of FOIT

Before this change, in chrome with cache disabled and Slow 3G:
![Webhint-3g-slow-before](https://user-images.githubusercontent.com/1302542/65983453-85cd1180-e44b-11e9-81eb-7def56a95b08.gif)

After this change, in chrome with cache disabled and Slow 3G:
![Webhint-3g-slow-after](https://user-images.githubusercontent.com/1302542/65983486-92ea0080-e44b-11e9-938f-07b9829af87a.gif)
