### PR TITLE
Docs: Fix typo on server documentation

### DIFF
--- a/architecture/server.md
+++ b/architecture/server.md
@@ -66,7 +66,7 @@ The deployment process is fully automated:
    This script will copy the required files for the deployment and push
    them into a local Git on Azure in the staging environment.
 1. The staging environment will be tested with `webhint` to make sure
-   everything is alrigh. If so, the code will get into production after
+   everything is alright. If so, the code will get into production after
    swapping slots in the Azure WebApp.
 
 ## Production configuration


### PR DESCRIPTION
Hi there!
I was taking a look at the repo in pair with @LeoSL and we found a typo on the documentation.
I saw that the guide to open Pull Requests mention that there should be an issue for any PR, I wonder if a typo like this would require an issue. Is it required?

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

Fixed a typo
