### PR TITLE
Update `Clear-Site-Data` value as quoted string

### DIFF
--- a/web.config
+++ b/web.config
@@ -94,7 +94,7 @@
                 <!-- Clean service worker from old site -->
                 <rule name="sonarwhal" enabled="true">
                     <match serverVariable="RESPONSE_Clear_Site_Data" pattern=".*" />
-                    <action type="Rewrite" value="storage" />
+                    <action type="Rewrite" value="\"storage\"" />
                 </rule>
 
                <!-- Restore the mime type for compressed assets. See below for more explanation -->


### PR DESCRIPTION
> The [`Clear-Site-Data` HTTP header's](https://w3c.github.io/webappsec-clear-site-data/#header) values "_MUST comply with the quoted-string grammar_", as defined in https://tools.ietf.org/html/rfc7230#section-3.2.6.

Fix #855.