### PR TITLE
Fix: Only send `Clear-Site-Data` for the root document (HTML)

### DIFF
--- a/web.config
+++ b/web.config
@@ -93,7 +93,7 @@
             <outboundRules>
                 <!-- Clean service worker from old site -->
                 <rule name="sonarwhal" enabled="true">
-                    <match serverVariable="RESPONSE_Clear_Site_Data" pattern=".*" />
+                    <match serverVariable="RESPONSE_Clear_Site_Data" pattern="\.html" />
                     <action type="Rewrite" value="&quot;storage&quot;" />
                 </rule>
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

After fixing the `Clear-Site-Data` header issue of unquoted string values
in https://github.com/webhintio/webhint.io/pull/856, a new console error has surfaced:

![clear-site-data_credentials-issue](https://user-images.githubusercontent.com/26493779/68058471-7d415280-fcf9-11e9-93d6-46a19bb62590.png)

While I don't believe this causes any real issues, to get rid of the console error, either:

- add `crossorigin="use-credentials"` to the manifest link relation
- only send the header in `text/html` responses to begin with.

This PR introduces the latter approach, which I think is more appropriate. The [spec says](https://w3c.github.io/webappsec-clear-site-data/) the various data types (`"cookie"`, `"storage"` etc.) are "_associated with the origin of a particular response’s url_", which I think implies that sending this header for sub-resources is unnecessary, and is the reason for this console error.

Edit: I should also mention that I tested this locally, sending `Clear-Site-Data: "cache"` for the document `text/html` forced the client to fetch all sub-resources from the server, whereas otherwise 304s were returned.