### PR TITLE
Fix: Send `Vary` header consistently.

### DIFF
--- a/web.config
+++ b/web.config
@@ -107,8 +107,8 @@
                     <action type="Rewrite" value="{C:3}" />
                 </rule>
                 <!-- add vary header -->
-                <rule name="AddVaryAcceptEncoding" preCondition="PreCompressedFile" enabled="true">
-                    <match serverVariable="RESPONSE_Vary" pattern=".*" />
+                <rule name="AddVaryAcceptEncoding" enabled="true">
+                    <match serverVariable="RESPONSE_Vary" pattern="\.(?:css|html|ico|js|map|svg|txt|xml|webmanifest)" />
                     <action type="Rewrite" value="Accept-Encoding" />
                 </rule>
                 <!-- indicate response is encoded with brotli -->
@@ -122,9 +122,6 @@
                     <action type="Rewrite" value="gzip" />
                 </rule>
                 <preConditions>
-                    <preCondition name="PreCompressedFile">
-                        <add input="{HTTP_URL}" pattern="\.((?:css|html|ico|js|map|svg|txt|xml|webmanifest)\.(gz|br))" />
-                    </preCondition>
                     <preCondition name="PreCompressedZopfli">
                         <add input="{HTTP_URL}" pattern="\.((?:css|html|ico|js|map|svg|txt|xml|webmanifest)\.gz)" />
                     </preCondition>


### PR DESCRIPTION
As mentioned in https://github.com/webhintio/hint/issues/624#issuecomment-548054372, RedBot is complaining about webhint.io not sending the `Vary` header consistently for all the representations of a resource.

Currently, the header is only being sent for `.br` and `.gz` files, thus a non-compressed representation of that resource is not eligible for varying the response (although I'm not sure when this would be the case outside of browsers not supporting gzip or brotli).

The explanation in the RedBot "hint" says:
> HTTP requires that the Vary response header be sent consistently for all responses if they change based upon different aspects of the request.
> 
> This resource has both compressed and uncompressed variants available, negotiated by the Accept-Encoding request header, but it sends different Vary headers for each;
> 
> "accept-encoding" when the response is compressed, and
> "-" when it is not.
> This can cause problems for downstream caches, because they cannot consistently determine what the cache key for a given URI is.

While I'm not sure everyone would agree this is a real issue, if you do think it's worth fixing, this PR removes the `PreCompressedFile` precondition, and match all the resources that is expected to be pre-compressed - but also in cases they aren't (by not narrowing down to only `.br` or `.gz` files per the current precondition).