### PR TITLE
Fix: Downgrade puppeteer verstion to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "mktemp": "^1.0.0",
     "normalize-path": "^3.0.0",
     "npm-run-all": "^4.1.3",
-    "puppeteer": "5.2.1",
+    "puppeteer": "5.0.0",
     "remove-markdown": "^0.3.0",
     "shelljs": "^0.8.3",
     "stylelint": "^13.0.0",


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

Apparently since the update to puppeteer 5.1.0 the staging tests
are failing with an error in the `http-compression` rule.

