### PR TITLE
Fix: Support mapping links to full URLs from `hint` Github repo

### DIFF
--- a/helpers/update-site/documentation.js
+++ b/helpers/update-site/documentation.js
@@ -545,6 +545,35 @@ const updateMarkdownlinks = (file) => {
 
     while ((val = mdLinkRegex.exec(content)) !== null) {
         /**
+         * Values:
+         *
+         * val[0]: Full string matched. E.g:
+         * * - `](./getting-started/architecture.md`
+         * * - `]: ../../user-guide/index.md`
+         * * - `](https://github.com/webhintio/hint/blob/HEAD/packages/hint/docs/user-guide/troubleshoot/summary.md`
+         *
+         * val[1]: First group matched (]:\s*|]\(). E.g:
+         * * - `](`
+         * * - `]: `
+         * * - `](`
+         *
+         * val[2]: Second group matched
+         *   (\.?\.\/|https:\/\/github.com\/webhintio\/hint\/blob\/HEAD\/(packages\/)?)
+         * E.g:
+         * * - `./`
+         * * - `../`
+         * * - `https://github.com/webhintio/hint/blob/HEAD/packages/`
+         *
+         * val[3]: Third group matched (packages\/). E.g:
+         * * - `undefined`
+         * * - `undefined`
+         * * - `packages/`
+         *
+         * val[4]: fourth group matched (\S*?). E.g:
+         * * - getting-started/architecture
+         * * - ../user-guide/index
+         * * - hint/docs/user-guide/troubleshoot/summary
+         *
          * Pages in the live site are `index.html` inside a folder with the name of the original page. E.g.:
          *
          * * `/user-guide/concepts/connectors.md` → `/user-guide/concepts/connectors/
@@ -574,11 +603,17 @@ const updateMarkdownlinks = (file) => {
          * In this case we need to replace it with the a valid
          * url in the website.
          */
-        if (val[2].startsWith('https')) {
-            replacement =
-                `${val[1]}/docs/${file.frontMatter.section}${file.frontMatter.tocTitle ? `/${file.frontMatter.tocTitle.replace(' ', '-')}` : ''}/${val[4].replace('/docs/', '/')}/`;
-
-            transformed = transformed.replace(val[0], replacement);
+        if (val[2].startsWith('https://github.com/')) {
+            /*
+             * Documentation in the package hint has to be parsed in a diferent way
+             * because it already has the folder structure in place.
+             */
+            if (val[4].startsWith('hint/docs/user-guide')) {
+                replacement = `${val[1]}${val[4].substr(4)}`;
+            } else {
+                replacement =
+                    `${val[1]}/docs/${file.frontMatter.section}${file.frontMatter.tocTitle ? `/${file.frontMatter.tocTitle.replace(' ', '-')}` : ''}/${val[4].replace('/docs/', '/')}/`;
+            }
         }
         /**
          * If val[0] contains './docs/ then, it is part of a multi-hint hint, so

--- a/helpers/update-site/documentation.js
+++ b/helpers/update-site/documentation.js
@@ -524,16 +524,21 @@ const getFilesInfo = (files) => {
 };
 
 /** Updates the markdown links to other parts of the documentation, i.e.: start with "./" */
-const updateMarkdownlinks = (content, filePath) => {
+const updateMarkdownlinks = (file) => {
+    const content = file.content;
+    const filePath = file.orig || file.dest;
     /**
      * This regex should match the following examples:
      * * [link label]: ./somewhere.md → \s
      * * [link label]:./somewhere.md → :
      * * [link](./somewhere.md)  → \(
+     * * [link](https://github.com/webhintio/hint/blob/HEAD/path-to-file/file.md)
+     * * [link]: https://github.com/webhintio/hint/blob/HEAD/path-to-file/file.md
+     * * [link]:https://github.com/webhintio/hint/blob/HEAD/path-to-file/file.md
      *
      * The \.? allow us to also match "../"
      */
-    const mdLinkRegex = /(\s|:|\()\.?\.\/(\S*?)\.md/gi;
+    const mdLinkRegex = /(]:\s*|]\()(\.?\.\/|https:\/\/github.com\/webhintio\/hint\/blob\/HEAD\/(packages\/)?)(\S*?)\.md/gi;
     const isIndex = filePath.toLowerCase().endsWith('index.md');
     let transformed = content;
     let val;
@@ -564,6 +569,17 @@ const updateMarkdownlinks = (content, filePath) => {
             val[0].replace(/(index|readme)\.md/i, '') :
             val[0].replace('.md', '/');
 
+        /*
+         * An github url is found for a md file.
+         * In this case we need to replace it with the a valid
+         * url in the website.
+         */
+        if (val[2].startsWith('https')) {
+            replacement =
+                `${val[1]}/docs/${file.frontMatter.section}${file.frontMatter.tocTitle ? `/${file.frontMatter.tocTitle.replace(' ', '-')}` : ''}/${val[4].replace('/docs/', '/')}/`;
+
+            transformed = transformed.replace(val[0], replacement);
+        }
         /**
          * If val[0] contains './docs/ then, it is part of a multi-hint hint, so
          * we need to ignore it.
@@ -571,7 +587,7 @@ const updateMarkdownlinks = (content, filePath) => {
          */
         if (!val[0].includes('./docs/')) {
             /**
-             * `val[1] is the first capturing group. It could be "\s", ":", or "("
+             * `val[1] is the first capturing group. It could be "]:\s", "]:", or "]("
              * and it's part of the matched value so we need to add it at the beginning as well. E.g.:
              *
              * * `[events](./events.md)` will match `(./events.md` that needs to be transformed into `(../events/`.
@@ -595,7 +611,7 @@ const updateLinks = (files) => {
             return;
         }
 
-        file.content = updateMarkdownlinks(file.content, file.orig || file.dest);
+        file.content = updateMarkdownlinks(file);
     });
 };
 


### PR DESCRIPTION
Fix #933

<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

<!--

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
