### PR TITLE
Chore: Init webhint.io telemetry so it submits

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -119,8 +119,13 @@ telemetry.initTelemetry({
                 reject(err);
             });
 
-            request.write(data);
-            request.end();
+            /*
+             * Don't use request.write or request will be sent chunked.
+             * Chunked requests break in node-based v2 Azure Functions,
+             * which are used to run the webhint telemetry service.
+             * https://github.com/Azure/azure-functions-host/issues/4926
+             */
+            request.end(data);
         });
     }
 });

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,5 +1,6 @@
 const bodyParser = require('body-parser');
 const fs = require('fs');
+const https = require('https');
 const path = require('path');
 const express = require('express');
 const yaml = require('js-yaml');
@@ -105,6 +106,24 @@ const listen = (app) => {
         console.log(`Server listening on port ${port}.`);
     });
 };
+
+telemetry.initTelemetry({
+    enabled: true,
+    post: (url, data) => {
+        return new Promise((resolve, reject) => {
+            const request = https.request(url, { method: 'POST' }, (response) => {
+                resolve(response.statusCode);
+            });
+
+            request.on('error', (err) => {
+                reject(err);
+            });
+
+            request.write(data);
+            request.end();
+        });
+    }
+});
 
 const server = createServer();
 


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

<!--

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
Most telemetry is part of the online scanner or submitted from the client,
but the `online-activity-url` event for keeping track of referring sources
relies on submitting telemetry from the express server powering the
documentation pages for webhint.io. 

Code was previously added to handle this event, but was not getting
submitted until now due to the telemetry package still needing initialized
with a `post` function.