### PR TITLE
Chore: Always use appInsights server-side

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "@hint/formatter-html": "^4.2.3",
     "@hint/utils": "^7.0.5",
     "@hint/utils-i18n": "^1.0.4",
-    "@hint/utils-telemetry": "^1.0.4",
     "algoliasearch": "^4.0.0",
     "applicationinsights": "^1.6.0",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
Eliminates the use of multiple packages for server-side telemetry.
Plus the `@hint/utils-telemetry` package is intended more for client-side usage.