### PR TITLE
Chore: Stop tracking request URLs in node

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -76,24 +76,7 @@ const configureRoutes = (app) => {
     require('./routes/changelog.js')(app);
 };
 
-const trackUrlTelemetry = (req, res, next) => {
-    const props = { url: req.url };
-
-    if (req.query.source !== void 0) {
-        props.source = req.query.source;
-    }
-
-    appInsightsClient.trackEvent({
-        name: 'online-activity-url',
-        properties: props
-    });
-
-    next();
-};
-
 const configureFallbacks = (app) => {
-    app.use(trackUrlTelemetry);
-
     app.use('/', express.static(path.join(rootPath, 'dist')));
 
     if (!production) {


### PR DESCRIPTION
These are now tracked automatically at the host layer.
The node-level approach was incomplete as most static
content is served from the host layer and controlled by
the included `web.config` file instead of being passed on
to the node server.